### PR TITLE
Enabled SourceLink

### DIFF
--- a/src/BCrypt.Net-Core/BCrypt.Net-Core.csproj
+++ b/src/BCrypt.Net-Core/BCrypt.Net-Core.csproj
@@ -22,4 +22,14 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" Condition="'$(TargetFramework)'=='netstandard1.3'"/>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Hi, this changes enable [SourceLink](https://github.com/dotnet/sourcelink) so applications using your nice port can step into the libs code if needed. 

Check my post on the matter here: [Adding SourceLink to your .NET Core Library](https://carlos.mendible.com/2018/08/25/adding-sourcelink-to-your-net-core-library/)

Hope it helps!